### PR TITLE
Removed libxml dependency

### DIFF
--- a/xcres.gemspec
+++ b/xcres.gemspec
@@ -38,5 +38,4 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'colored', '~> 1.2'
   spec.add_runtime_dependency 'activesupport', '>= 3.2.15', '< 4'
   spec.add_runtime_dependency 'xcodeproj', '~> 0.18'
-  spec.add_runtime_dependency 'libxml-ruby'
 end


### PR DESCRIPTION
I didn't find any usage of libxml in the project and the gem works like a charm without it.
The dependency caused some problems for my project when trying to install it in a 'virtual ruby environment'.

Cheers 

Simon