### PR TITLE
Not generating empty structs.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    xcres (0.4.4)
+    xcres (0.4.5)
       activesupport (>= 3.2.15, < 4)
       clamp (~> 0.6.3)
       colored (~> 1.2)
@@ -11,32 +11,33 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (3.2.19)
+    activesupport (3.2.22)
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     ast (2.0.0)
     bacon (1.2.0)
-    clamp (0.6.3)
+    claide (0.9.1)
+    clamp (0.6.5)
     clintegracon (0.5.2)
       colored (~> 1.2)
       diffy
     coderay (1.1.0)
     colored (1.2)
     diffy (3.0.6)
-    i18n (0.6.11)
+    i18n (0.7.0)
     inch (0.4.10)
       pry
       sparkr (>= 0.2.0)
       term-ansicolor
       yard (~> 0.8.7)
-    libxml-ruby (2.7.0)
+    libxml-ruby (2.8.0)
     metaclass (0.0.4)
     method_source (0.8.2)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     mocha-on-bacon (0.2.2)
       mocha (>= 0.13.0)
-    multi_json (1.10.1)
+    multi_json (1.11.2)
     parser (2.2.0.pre.4)
       ast (>= 1.1, < 3.0)
       slop (~> 3.4, >= 3.4.5)
@@ -61,8 +62,9 @@ GEM
     term-ansicolor (1.3.0)
       tins (~> 1.0)
     tins (1.3.2)
-    xcodeproj (0.19.4)
-      activesupport (~> 3.0)
+    xcodeproj (0.28.2)
+      activesupport (>= 3)
+      claide (~> 0.9.1)
       colored (~> 1.2)
     yard (0.8.7.4)
 
@@ -81,3 +83,6 @@ DEPENDENCIES
   rake
   rubocop
   xcres!
+
+BUNDLED WITH
+   1.10.6

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ All you need to do is to add an import to the generated header to your
 project's bridging header.
 
 ```objc
-const struct R {
+FOUNDATION_EXTERN const struct R {
     struct Images {
         /// doge.jpeg
         __unsafe_unretained NSString *doge;

--- a/lib/xcres/builder/resources_builder.rb
+++ b/lib/xcres/builder/resources_builder.rb
@@ -126,7 +126,7 @@ EOS
       h_file.writeln
       h_file.writeln '#import <Foundation/Foundation.h>'
       h_file.writeln
-      h_file.writeln 'extern const struct %s {' % resources_constant_name
+      h_file.writeln 'FOUNDATION_EXTERN const struct %s {' % resources_constant_name
       h_file.section do |struct|
         enumerate_sections do |section_key, enumerate_keys, contents_count|
           if contents_count > 0

--- a/lib/xcres/builder/resources_builder.rb
+++ b/lib/xcres/builder/resources_builder.rb
@@ -128,17 +128,19 @@ EOS
       h_file.writeln
       h_file.writeln 'extern const struct %s {' % resources_constant_name
       h_file.section do |struct|
-        enumerate_sections do |section_key, enumerate_keys|
-          struct.writeln 'struct %s {' % section_key
-          struct.section do |section_struct|
-            enumerate_keys.call do |key, value, comment|
-              if documented?
-                section_struct.writeln '/// %s' % (comment || value) #unless comment.nil?
+        enumerate_sections do |section_key, enumerate_keys, contents_count|
+          if contents_count > 0
+            struct.writeln 'struct %s {' % section_key
+            struct.section do |section_struct|
+              enumerate_keys.call do |key, value, comment|
+                if documented?
+                  section_struct.writeln '/// %s' % (comment || value) #unless comment.nil?
+                end
+                section_struct.writeln '__unsafe_unretained NSString *%s;' % key
               end
-              section_struct.writeln '__unsafe_unretained NSString *%s;' % key
             end
+            struct.writeln '} %s;' % section_key
           end
-          struct.writeln '} %s;' % section_key
         end
       end
       h_file.writeln '} %s;' % resources_constant_name
@@ -151,14 +153,16 @@ EOS
       m_file.writeln
       m_file.writeln 'const struct %s %s = {' % [resources_constant_name, resources_constant_name]
       m_file.section do |struct|
-        enumerate_sections do |section_key, enumerate_keys|
-          struct.writeln '.%s = {' % section_key
-          struct.section do |section_struct|
-            enumerate_keys.call do |key, value|
-              section_struct.writeln '.%s = @"%s",' % [key, value]
+        enumerate_sections do |section_key, enumerate_keys, contents_count|
+          if contents_count > 0
+            struct.writeln '.%s = {' % section_key
+            struct.section do |section_struct|
+              enumerate_keys.call do |key, value|
+                section_struct.writeln '.%s = @"%s",' % [key, value]
+              end
             end
+            struct.writeln '},'
           end
-          struct.writeln '},'
         end
       end
       m_file.writeln '};'
@@ -177,7 +181,7 @@ EOS
             end
           end
         end
-        yield section_key, proc
+        yield section_key, proc, section_content.length
       end
     end
 

--- a/lib/xcres/version.rb
+++ b/lib/xcres/version.rb
@@ -4,6 +4,6 @@ module XCRes
   #
   #   XCRes’s version, following [semver](http://semver.org).
   #
-  VERSION = "0.4.4"
+  VERSION = "0.4.5"
 
 end

--- a/spec/integration/build-keyword-clash/after/R.h
+++ b/spec/integration/build-keyword-clash/after/R.h
@@ -8,6 +8,4 @@
 #import <Foundation/Foundation.h>
 
 extern const struct R {
-    struct Strings {
-    } Strings;
 } R;

--- a/spec/integration/build-keyword-clash/after/R.h
+++ b/spec/integration/build-keyword-clash/after/R.h
@@ -7,5 +7,5 @@
 
 #import <Foundation/Foundation.h>
 
-extern const struct R {
+FOUNDATION_EXTERN const struct R {
 } R;

--- a/spec/integration/build-keyword-clash/after/R.m
+++ b/spec/integration/build-keyword-clash/after/R.m
@@ -8,6 +8,4 @@
 #import "R.h"
 
 const struct R R = {
-    .Strings = {
-    },
 };

--- a/spec/integration/build-var-infoplist/after/R.h
+++ b/spec/integration/build-var-infoplist/after/R.h
@@ -7,7 +7,7 @@
 
 #import <Foundation/Foundation.h>
 
-extern const struct R {
+FOUNDATION_EXTERN const struct R {
     struct Icons {
         /// tab_bar/tabbar_list.png
         __unsafe_unretained NSString *tabBarList;

--- a/spec/integration/build/after/R.h
+++ b/spec/integration/build/after/R.h
@@ -7,7 +7,7 @@
 
 #import <Foundation/Foundation.h>
 
-extern const struct R {
+FOUNDATION_EXTERN const struct R {
     struct Icons {
         /// tab_bar/tabbar_list.png
         __unsafe_unretained NSString *tabBarList;

--- a/spec/integration/install-again/after/Example/Example/Resources/R.h
+++ b/spec/integration/install-again/after/Example/Example/Resources/R.h
@@ -14,6 +14,4 @@ extern const struct R {
         /// LaunchImage
         __unsafe_unretained NSString *launch;
     } ImagesAssets;
-    struct Strings {
-    } Strings;
 } R;

--- a/spec/integration/install-again/after/Example/Example/Resources/R.h
+++ b/spec/integration/install-again/after/Example/Example/Resources/R.h
@@ -7,7 +7,7 @@
 
 #import <Foundation/Foundation.h>
 
-extern const struct R {
+FOUNDATION_EXTERN const struct R {
     struct ImagesAssets {
         /// AppIcon
         __unsafe_unretained NSString *app;

--- a/spec/integration/install-again/after/Example/Example/Resources/R.m
+++ b/spec/integration/install-again/after/Example/Example/Resources/R.m
@@ -12,6 +12,4 @@ const struct R R = {
         .app = @"AppIcon",
         .launch = @"LaunchImage",
     },
-    .Strings = {
-    },
 };

--- a/spec/integration/install-again/after/execution_output.txt
+++ b/spec/integration/install-again/after/execution_output.txt
@@ -18,6 +18,5 @@ Execute build first:
     Ⓥ Strings files after language selection: ["en.lproj/InfoPlist.strings"]
     Ⓥ Non-ignored .strings files: []
     ✓ Existing file is up-to-date. Don't touch.
-    ✓ Existing file is up-to-date. Don't touch.
     ✓ Successfully updated: ROOT/tmp/integration/install-again/Example/Example/Resources/R.h
 ✓ Successfully integrated into Example/Example.xcodeproj

--- a/spec/integration/install-again/before/Example/Example/Resources/R.h
+++ b/spec/integration/install-again/before/Example/Example/Resources/R.h
@@ -7,7 +7,7 @@
 
 #import <Foundation/Foundation.h>
 
-extern const struct R {
+FOUNDATION_EXTERN const struct R {
     struct ImagesAssets {
         /// AppIcon
         __unsafe_unretained NSString *app;

--- a/spec/integration/install-again/before/Example/Example/Resources/R.m
+++ b/spec/integration/install-again/before/Example/Example/Resources/R.m
@@ -12,6 +12,4 @@ const struct R R = {
         .app = @"AppIcon",
         .launch = @"LaunchImage",
     },
-    .Strings = {
-    },
 };

--- a/spec/integration/install-moved-supporting-files/after/Example/Supporting_Files/Resources/R.h
+++ b/spec/integration/install-moved-supporting-files/after/Example/Supporting_Files/Resources/R.h
@@ -14,6 +14,4 @@ extern const struct R {
         /// LaunchImage
         __unsafe_unretained NSString *launch;
     } ImagesAssets;
-    struct Strings {
-    } Strings;
 } R;

--- a/spec/integration/install-moved-supporting-files/after/Example/Supporting_Files/Resources/R.h
+++ b/spec/integration/install-moved-supporting-files/after/Example/Supporting_Files/Resources/R.h
@@ -7,7 +7,7 @@
 
 #import <Foundation/Foundation.h>
 
-extern const struct R {
+FOUNDATION_EXTERN const struct R {
     struct ImagesAssets {
         /// AppIcon
         __unsafe_unretained NSString *app;

--- a/spec/integration/install-moved-supporting-files/after/Example/Supporting_Files/Resources/R.m
+++ b/spec/integration/install-moved-supporting-files/after/Example/Supporting_Files/Resources/R.m
@@ -12,6 +12,4 @@ const struct R R = {
         .app = @"AppIcon",
         .launch = @"LaunchImage",
     },
-    .Strings = {
-    },
 };

--- a/spec/integration/install-no-supporting-files/after/Example/Resources/R.h
+++ b/spec/integration/install-no-supporting-files/after/Example/Resources/R.h
@@ -14,6 +14,4 @@ extern const struct R {
         /// LaunchImage
         __unsafe_unretained NSString *launch;
     } ImagesAssets;
-    struct Strings {
-    } Strings;
 } R;

--- a/spec/integration/install-no-supporting-files/after/Example/Resources/R.h
+++ b/spec/integration/install-no-supporting-files/after/Example/Resources/R.h
@@ -7,7 +7,7 @@
 
 #import <Foundation/Foundation.h>
 
-extern const struct R {
+FOUNDATION_EXTERN const struct R {
     struct ImagesAssets {
         /// AppIcon
         __unsafe_unretained NSString *app;

--- a/spec/integration/install-no-supporting-files/after/Example/Resources/R.m
+++ b/spec/integration/install-no-supporting-files/after/Example/Resources/R.m
@@ -12,6 +12,4 @@ const struct R R = {
         .app = @"AppIcon",
         .launch = @"LaunchImage",
     },
-    .Strings = {
-    },
 };

--- a/spec/integration/install/after/Example/Example/Resources/R.h
+++ b/spec/integration/install/after/Example/Example/Resources/R.h
@@ -14,6 +14,4 @@ extern const struct R {
         /// LaunchImage
         __unsafe_unretained NSString *launch;
     } ImagesAssets;
-    struct Strings {
-    } Strings;
 } R;

--- a/spec/integration/install/after/Example/Example/Resources/R.h
+++ b/spec/integration/install/after/Example/Example/Resources/R.h
@@ -7,7 +7,7 @@
 
 #import <Foundation/Foundation.h>
 
-extern const struct R {
+FOUNDATION_EXTERN const struct R {
     struct ImagesAssets {
         /// AppIcon
         __unsafe_unretained NSString *app;

--- a/spec/integration/install/after/Example/Example/Resources/R.m
+++ b/spec/integration/install/after/Example/Example/Resources/R.m
@@ -12,6 +12,4 @@ const struct R R = {
         .app = @"AppIcon",
         .launch = @"LaunchImage",
     },
-    .Strings = {
-    },
 };

--- a/spec/integration/version/after/execution_output.txt
+++ b/spec/integration/version/after/execution_output.txt
@@ -1,3 +1,3 @@
  xcres version --verbose --no-ansi 2>&1
 Ⓥ Verbose mode is enabled.
-0.4.4
+0.4.5


### PR DESCRIPTION
I came across the problem, where a struct that is defined after an empty one would have its values shifted in the runtime for some reason (building with Xcode 7.1). For instance, I have a code:

```
...
struct ImagesAssets {
// bunch of stuff. works well
...
} ImagesAssets;
struct Strings {
} Strings;
struct OtherAssets {
   __unsafe_unretained NSString *first; // Will have a value of second
   __unsafe_unretained NSString *second; // Will have a null value, if it's the last attribute. Otherwise will have value of third
} OtherAssets;
...
```

By eliminating empty Strings struct I managed to fix the behavior.