### PR TITLE
Reject Interface Builder Ids with two characters in middle section

### DIFF
--- a/lib/xcres/analyzer/strings_analyzer.rb
+++ b/lib/xcres/analyzer/strings_analyzer.rb
@@ -233,7 +233,7 @@ module XCRes
         strings = read_strings_file(path)
 
         # Reject generated identifiers used by Interface Builder
-        strings.reject! { |key, _| /^[a-zA-Z0-9]{3}(-[a-zA-Z0-9]{3}){2}/.match(key) }
+        strings.reject! { |key, _| /^[a-zA-Z0-9]{3}-[a-zA-Z0-9]{2,3}-[a-zA-Z0-9]{3}/.match(key) }
 
         keys = Hash[strings.map do |key, value|
           [key, { value: key, comment: value.gsub(/[\r\n]/, ' ') }]

--- a/spec/fixtures/Example/Example/en.lproj/Localizable.strings
+++ b/spec/fixtures/Example/Example/en.lproj/Localizable.strings
@@ -16,3 +16,4 @@
 
 // Strings from Storyboards
 "123-abc-3e7.text" = "Hello Storyboards";
+"123-ab-3e7.text" = "Hello Storyboards";

--- a/spec/unit/analyzer/strings_analyzer_spec.rb
+++ b/spec/unit/analyzer/strings_analyzer_spec.rb
@@ -238,6 +238,7 @@ describe 'XCRes::StringsAnalyzer' do
         "en_exclusive"      => "Only in english",
         "example"           => "Lorem Ipsum",
         "123-abc-3e7.text"  => "Hello Storyboards",
+        "123-ab-3e7.text"   => "Hello Storyboards",
       }
     end
 


### PR DESCRIPTION
I've checked multiple storyboards created by me or my coworkers, and all of the
Interface Builder Object IDs only had two instead of three characters in the
middle section.

I'm not sure if there are differences in Object ID format based on Xcode
version or document settings of the storyboard/xib files.