### PR TITLE
Removes < 4 dependency for activessupport

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,20 +2,23 @@ PATH
   remote: .
   specs:
     xcres (0.6.0)
-      activesupport (>= 3.2.15, < 4)
+      activesupport (>= 4.0.2, < 5)
       clamp (~> 0.6.3)
       colored (~> 1.2)
-      xcodeproj (>= 0.28.2, < 1.1.0)
+      xcodeproj (>= 1.2.0, < 2.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (3.2.22.2)
-      i18n (~> 0.6, >= 0.6.4)
-      multi_json (~> 1.0)
+    activesupport (4.2.7)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
     ast (2.2.0)
     bacon (1.2.0)
-    claide (0.9.1)
+    claide (1.0.0)
     clamp (0.6.5)
     clintegracon (0.8.1)
       colored (~> 1.2)
@@ -29,13 +32,14 @@ GEM
       sparkr (>= 0.2.0)
       term-ansicolor
       yard (~> 0.8.7.5)
+    json (1.8.3)
     metaclass (0.0.4)
     method_source (0.8.2)
+    minitest (5.9.0)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     mocha-on-bacon (0.2.2)
       mocha (>= 0.13.0)
-    multi_json (1.11.2)
     parser (2.3.0.6)
       ast (~> 2.2)
     powerpack (0.1.1)
@@ -59,11 +63,14 @@ GEM
     sparkr (0.4.1)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
+    thread_safe (0.3.5)
     tins (1.9.0)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
     unicode-display_width (1.0.2)
-    xcodeproj (0.28.2)
+    xcodeproj (1.2.0)
       activesupport (>= 3)
-      claide (~> 0.9.1)
+      claide (>= 1.0.0, < 2.0)
       colored (~> 1.2)
     yard (0.8.7.6)
 
@@ -84,4 +91,4 @@ DEPENDENCIES
   xcres!
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/xcres.gemspec
+++ b/xcres.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'clamp', '~> 0.6.3'
   spec.add_runtime_dependency 'colored', '~> 1.2'
-  spec.add_runtime_dependency 'activesupport', '>= 3.2.15', '< 4'
-  spec.add_runtime_dependency 'xcodeproj', ">= 0.28.2", "< 1.1.0"
+  ## Version 5 needs Ruby 2.2, so we specify an upper bound to stay compatible with system ruby
+  spec.add_runtime_dependency 'activesupport', '>= 4.0.2', '< 5'
+  spec.add_runtime_dependency 'xcodeproj', '>= 1.2.0', '< 2.0'
 end


### PR DESCRIPTION
It conflicts with Cocoapods 1.x, which a lot of the users of this library use in tandem. 
Fixes #31 

To be seen if there was a hard reason to keep this dependency like this, eg does something in Active support 4.0 break?